### PR TITLE
Supress the `yarn install` warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "devDependencies": {
     "lerna": "^4.0.0"
   },
+  "resolutions": {
+    "qaci-cli/circomlib": "https://github.com/weijiekoh/circomlib.git#24ed08eee0bb613b8c0135d66c1013bd9f78d50a",
+    "qaci-crypto/circomlib": "https://github.com/weijiekoh/circomlib.git#24ed08eee0bb613b8c0135d66c1013bd9f78d50a"
+  },
   "workspaces": {
     "packages": [
       "packages/*"


### PR DESCRIPTION
fixes: https://github.com/quadratic-funding/qfi/issues/78, https://github.com/quadratic-funding/qfi/issues/79