### PR TITLE
Add a CI for contracts package and frontend

### DIFF
--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -1,0 +1,78 @@
+name: Contracts-Build
+
+on:
+  push: 
+    branches: [ main, dev ]
+    tags: ['*']
+  pull_request:
+
+env:
+  cwd: ${{github.workspace}}/packages/contracts
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+
+  unit-test-and-lint:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+          
+      - name: Lint
+        run: |
+          yarn workspace @quadratic-funding/contracts run lint:solidity
+          yarn workspace @quadratic-funding/contracts run lint:js
+
+      - name: Run Unit Test
+        run: |
+          yarn workspace @quadratic-funding/contracts run generate:abi
+          yarn workspace @quadratic-funding/contracts run test:unit
+
+  qv-test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+          
+      - name: Run QV Test
+        run: |
+          yarn workspace @quadratic-funding/contracts run typechain
+          yarn workspace @quadratic-funding/contracts test:qv
+
+  qf-test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run QF Test
+        run: |
+          yarn workspace @quadratic-funding/contracts run typechain
+          yarn workspace @quadratic-funding/contracts run test:qf

--- a/.github/workflows/contracts-coverage.yml
+++ b/.github/workflows/contracts-coverage.yml
@@ -1,0 +1,43 @@
+name: Contracts-Coverage
+
+on:
+  push: 
+    branches: [ main ]
+
+env:
+  cwd: ${{github.workspace}}/packages/contracts
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+
+   coverage:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+          
+      - name: Lint
+        run: |
+          yarn workspace @quadratic-funding/contracts run lint:solidity
+          yarn workspace @quadratic-funding/contracts run lint:js
+
+      - name: Test Contract
+        run: |
+          yarn workspace @quadratic-funding/contracts run generate:abi
+          yarn workspace @quadratic-funding/contracts run test:coverage
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v2
+        with:
+          files: ${{env.cwd}}/coverage.json

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,34 @@
+name: Frontend-Build
+
+on:
+  push: 
+    branches: [ main, dev ]
+    tags: ['*']
+  pull_request:
+
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+          
+      - name: Build
+        run: |
+          CI=false yarn workspace @qfi/app build
+          CI=false yarn workspace @qfi/hooks build
+          CI=false yarn workspace @qfi/ui build

--- a/.github/workflows/frontend-lighthouse.yml
+++ b/.github/workflows/frontend-lighthouse.yml
@@ -1,0 +1,59 @@
+name: Frontend-Lighthouse
+
+on: 
+  issue_comment:
+    types: [ edited ]
+
+jobs:
+  capture_vercel_preview_url:
+    name: Capture Vercel preview URL
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: aaimio/vercel-preview-url-action@v1
+        id: vercel_preview_url
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v3
+      - name: Audit preview URL with Lighthouse
+        id: lighthouse_audit
+        uses: treosh/lighthouse-ci-action@v9
+        with:
+          urls: ${{ steps.vercel_preview_url.outputs.vercel_preview_url }}
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+
+      - name: Format lighthouse score
+        id: format_lighthouse_score
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const result = ${{ steps.lighthouse_audit.outputs.manifest }}[0].summary
+            const links = ${{ steps.lighthouse_audit.outputs.links }}
+            const formatResult = (res) => Math.round((res * 100))
+            Object.keys(result).forEach(key => result[key] = formatResult(result[key]))
+            const score = res => res >= 90 ? '🟢' : res >= 50 ? '🟠' : '🔴'
+            const comment = [
+                `⚡️ [Lighthouse report](${Object.values(links)[0]}) for the changes in this PR:`,
+                '| Category | Score |',
+                '| --- | --- |',
+                `| ${score(result.performance)} Performance | ${result.performance} |`,
+                `| ${score(result.accessibility)} Accessibility | ${result.accessibility} |`,
+                `| ${score(result['best-practices'])} Best practices | ${result['best-practices']} |`,
+                `| ${score(result.seo)} SEO | ${result.seo} |`,
+                `| ${score(result.pwa)} PWA | ${result.pwa} |`,
+                ' ',
+                `*Lighthouse ran on [${Object.keys(links)[0]}](${Object.keys(links)[0]})*`
+            ].join('\n')
+            core.setOutput("comment", comment); 
+
+      - name: Add comment to PR
+        id: comment_to_pr
+        uses: marocchino/sticky-pull-request-comment@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.issue.number }}
+          header: lighthouse
+          message: |
+            ${{ steps.format_lighthouse_score.outputs.comment }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+### CI/CD pipeline
+
+CI/CD pipeline ensures that we have automated tests that constantly validate that we are in a deployable state. For more information about pipeline workflows, see https://hackmd.io/@mdhackmdkakao/rkoVmtr75.


### PR DESCRIPTION
This PR activates CI to check pull requests for contracts package or frontend.
Documentation for CI/CD pipeline can be found [here](https://hackmd.io/@mdhackmdkakao/rkoVmtr75).

### Every PR will trigger tests on

contracts package
* unit test and linting
* qv test
* qf test

frontend
* Check build of `packages/app`, `packages/hooks`, `packages/subgraph`
* Lighthouse audit (only if there are changes to the above packages)

### Push event on `main` branch
Code coverage report will be generated for push events for the `main` branch. 

