### PR TITLE
Change `tests/` imports from `build/` to `typechain/` folder

### DIFF
--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -31,7 +31,7 @@ jobs:
           
       - name: Run Unit Test
         run: |
-          yarn workspace @quadratic-funding/contracts run generate:abi
+          yarn workspace @quadratic-funding/contracts run typechain
           yarn workspace @quadratic-funding/contracts run test:unit
 
       - name: Lint

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -15,7 +15,6 @@
     "prepare:prod-circuits": "mustache config/prod.json zkeys.config.template.yaml > zkeys.config.yml",
     "generate:zkey": "npx zkey-manager compile -c zkeys.config.yml",
     "generate:zkeys": "yarn prepare:small-circuits && npx zkey-manager compile -c zkeys.config.yml && yarn prepare:medium-circuits && npx zkey-manager compile -c zkeys.config.yml",
-    "generate:abi": "yarn hardhat export-abi",
     "test": "hardhat test",
     "test:unit": "yarn test tests/Unit/**.ts",
     "test:qv": "yarn test tests/QV/**.ts",

--- a/packages/contracts/tests/Unit/BaseRecipientRegistry.ts
+++ b/packages/contracts/tests/Unit/BaseRecipientRegistry.ts
@@ -1,7 +1,7 @@
 import { ethers } from "hardhat";
-import { ContractTransaction, ContractReceipt, Signer, constants } from "ethers";
+import { ContractTransaction, ContractReceipt, Signer } from "ethers";
 import chai from "chai";
-import { deployContract, deployMockContract, MockContract, solidity, } from "ethereum-waffle";
+import { solidity } from "ethereum-waffle";
 import { SimpleRecipientRegistry } from "../../typechain";
 
 chai.use(solidity);

--- a/packages/contracts/tests/Unit/FundsManager.ts
+++ b/packages/contracts/tests/Unit/FundsManager.ts
@@ -2,8 +2,7 @@ import { ethers } from "hardhat";
 import chai from "chai";
 import { deployMockContract, MockContract, solidity } from "ethereum-waffle";
 import { ContractTransaction, Signer } from "ethers";
-import { FundsManager, FundsManager__factory } from "../../typechain";
-import BaseERC20TokenAbi from "../../abi/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json";
+import { FundsManager, FundsManager__factory, BaseERC20Token__factory } from "../../typechain";
 
 chai.use(solidity);
 const { expect } = chai;
@@ -29,7 +28,7 @@ describe("Funds Manager", () => {
     fundingSourceAddress = await fundingSource.getAddress();
 
     // Mocked contracts.
-    mockBaseERC20Token = await deployMockContract(deployer, BaseERC20TokenAbi);
+    mockBaseERC20Token = await deployMockContract(deployer, BaseERC20Token__factory.abi);
 
     // nb. workaround due it's not possible to use Waffle library for linking libraries.
     // ISSUE -> https://github.com/EthWorks/Waffle/issues/429.

--- a/packages/contracts/tests/Unit/GrantRound.ts
+++ b/packages/contracts/tests/Unit/GrantRound.ts
@@ -13,13 +13,13 @@ import {
   PoseidonT4__factory,
   PoseidonT5__factory,
   PoseidonT6__factory,
+  BaseERC20Token__factory,
+  VkRegistry__factory,
+  OptimisticRecipientRegistry__factory,
+  QFI__factory,
+  AccQueue__factory,
+  AccQueueQuinaryBlankSl__factory
 } from "../../typechain";
-import BaseERC20TokenAbi from "../../abi/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json";
-import VkRegistryAbi from "../../abi/qaci-contracts/contracts/VkRegistry.sol/VkRegistry.json";
-import RecipientRegistryAbi from "../../abi/contracts/recipientRegistry/OptimisticRecipientRegistry.sol/OptimisticRecipientRegistry.json";
-import QfiAbi from "../../abi/contracts/QFI.sol/QFI.json";
-import MessageAqAbi from "../../abi/qaci-contracts/contracts/trees/AccQueue.sol/AccQueue.json";
-import AccQueueQuinaryBlankSlAbi from "../../abi/qaci-contracts/contracts/trees/AccQueue.sol/AccQueueQuinaryBlankSl.json";
 import { Command, Keypair } from "qaci-domainobjs";
 import { MessageStruct } from "../../typechain/GrantRound";
 import { hash4, hash5 } from "qaci-crypto";
@@ -100,17 +100,17 @@ describe("Grant Round", () => {
     recipientAddress = await recipient.getAddress();
 
     // Mocked contracts.
-    mockBaseERC20Token = await deployMockContract(deployer, BaseERC20TokenAbi);
+    mockBaseERC20Token = await deployMockContract(deployer, BaseERC20Token__factory.abi);
     mockRecipientRegistry = await deployMockContract(
       deployer,
-      RecipientRegistryAbi
+      OptimisticRecipientRegistry__factory.abi
     );
-    mockQfi = await deployMockContract(deployer, QfiAbi);
-    mockMessageAq = await deployMockContract(deployer, MessageAqAbi);
-    mockVkRegistry = await deployMockContract(deployer, VkRegistryAbi);
+    mockQfi = await deployMockContract(deployer, QFI__factory.abi);
+    mockMessageAq = await deployMockContract(deployer, AccQueue__factory.abi);
+    mockVkRegistry = await deployMockContract(deployer, VkRegistry__factory.abi);
     mockMaciStateAq = await deployMockContract(
       deployer,
-      AccQueueQuinaryBlankSlAbi
+      AccQueueQuinaryBlankSl__factory.abi
     );
 
     // External contracts for Grant Round.

--- a/packages/contracts/tests/Unit/GrantRoundFactory.ts
+++ b/packages/contracts/tests/Unit/GrantRoundFactory.ts
@@ -14,14 +14,14 @@ import {
   PoseidonT4__factory,
   PoseidonT5__factory,
   PoseidonT6__factory,
+  MessageAqFactory__factory,
+  AccQueue__factory,
+  OptimisticRecipientRegistry__factory,
+  QFI__factory,
+  VkRegistry__factory,
+  GrantRound__factory,
+  BaseERC20Token__factory
 } from "../../typechain";
-import MessageAqFactoryAbi from "../../abi/qaci-contracts/contracts/Poll.sol/MessageAqFactory.json";
-import MessageAqAbi from "../../abi/qaci-contracts/contracts/trees/AccQueue.sol/AccQueue.json";
-import RecipientRegistryAbi from "../../abi/contracts/recipientRegistry/OptimisticRecipientRegistry.sol/OptimisticRecipientRegistry.json";
-import QfiAbi from "../../abi/contracts/QFI.sol/QFI.json";
-import BaseERC20TokenAbi from "../../abi/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json";
-import VkRegistryAbi from "../../abi/qaci-contracts/contracts/VkRegistry.sol/VkRegistry.json";
-import GrantRoundAbi from "../../abi/contracts/GrantRound.sol/GrantRound.json";
 import { Keypair } from "qaci-domainobjs";
 
 chai.use(solidity);
@@ -126,7 +126,7 @@ describe("Grant Round Factory", () => {
       // Mocks.
       mockMessageAqFactory = await deployMockContract(
         deployer,
-        MessageAqFactoryAbi
+        MessageAqFactory__factory.abi
       );
     });
 
@@ -152,7 +152,7 @@ describe("Grant Round Factory", () => {
 
       mockMessageAqFactory = await deployMockContract(
         deployer,
-        MessageAqFactoryAbi
+        MessageAqFactory__factory.abi
       );
 
       expect(await grantRoundFactory.messageAqFactory()).to.be.not.equal(
@@ -186,7 +186,7 @@ describe("Grant Round Factory", () => {
       // Mocks.
       mockRecipientRegistry = await deployMockContract(
         deployer,
-        RecipientRegistryAbi
+        OptimisticRecipientRegistry__factory.abi
       );
     });
 
@@ -212,7 +212,7 @@ describe("Grant Round Factory", () => {
 
       mockRecipientRegistry = await deployMockContract(
         deployer,
-        RecipientRegistryAbi
+        OptimisticRecipientRegistry__factory.abi
       );
 
       expect(await grantRoundFactory.recipientRegistry()).to.be.not.equal(
@@ -254,18 +254,18 @@ describe("Grant Round Factory", () => {
 
     beforeEach(async () => {
       // Mocks.
-      mockQfi = await deployMockContract(deployer, QfiAbi);
+      mockQfi = await deployMockContract(deployer, QFI__factory.abi);
 
       mockBaseERC20Token = await deployMockContract(
         deployer,
-        BaseERC20TokenAbi
+        BaseERC20Token__factory.abi
       );
 
-      mockVkRegistry = await deployMockContract(deployer, VkRegistryAbi);
+      mockVkRegistry = await deployMockContract(deployer, VkRegistry__factory.abi);
 
-      mockGrantRound = await deployMockContract(deployer, GrantRoundAbi);
+      mockGrantRound = await deployMockContract(deployer, GrantRound__factory.abi);
 
-      mockMessageAq = await deployMockContract(deployer, MessageAqAbi);
+      mockMessageAq = await deployMockContract(deployer, AccQueue__factory.abi);
     });
 
     it.skip("allow owner to deploy a grant round", async () => {

--- a/packages/contracts/tests/Unit/OptimisticRecipientRegistry.ts
+++ b/packages/contracts/tests/Unit/OptimisticRecipientRegistry.ts
@@ -1,7 +1,7 @@
 import { ethers } from "hardhat";
-import { ContractTransaction, ContractReceipt, Signer, constants } from "ethers";
+import { ContractTransaction, ContractReceipt, Signer } from "ethers";
 import chai from "chai";
-import { deployContract, deployMockContract, MockContract, solidity, } from "ethereum-waffle";
+import { solidity } from "ethereum-waffle";
 import { OptimisticRecipientRegistry } from "../../typechain";
 
 chai.use(solidity);

--- a/packages/contracts/tests/Unit/QFI.ts
+++ b/packages/contracts/tests/Unit/QFI.ts
@@ -13,16 +13,16 @@ import {
   PoseidonT6__factory,
   QFI,
   QFI__factory,
+  GrantRoundFactory__factory,
+  BaseERC20Token__factory,
+  PollFactory__factory,
+  SignUpGatekeeper__factory,
+  ConstantInitialVoiceCreditProxy__factory,
+  VkRegistry__factory,
+  MessageAqFactory__factory,
+  PollProcessorAndTallyer__factory,
+  GrantRound__factory
 } from "../../typechain";
-import GrantRoundFactoryAbi from "../../abi/contracts/GrantRoundFactory.sol/GrantRoundFactory.json";
-import BaseERC20TokenAbi from "../../abi/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json";
-import PollFactoryAbi from "../../abi/qaci-contracts/contracts/Poll.sol/PollFactory.json";
-import SignUpGateKeeperAbi from "../../abi/qaci-contracts/contracts/gatekeepers/FreeForAllSignUpGatekeeper.sol/FreeForAllGatekeeper.json";
-import ConstantInitialVoiceCreditProxyAbi from "../../abi/qaci-contracts/contracts/initialVoiceCreditProxy/ConstantInitialVoiceCreditProxy.sol/ConstantInitialVoiceCreditProxy.json";
-import VkRegistryAbi from "../../abi/qaci-contracts/contracts/VkRegistry.sol/VkRegistry.json";
-import MessageAqFactoryAbi from "../../abi/qaci-contracts/contracts/Poll.sol/MessageAqFactory.json";
-import PollProcessorAndTallyerAbi from "../../abi/qaci-contracts/contracts/Poll.sol/PollProcessorAndTallyer.json";
-import GrantRoundAbi from "../../abi/contracts/GrantRound.sol/GrantRound.json";
 import { Keypair } from "qaci-domainobjs";
 
 chai.use(solidity);
@@ -108,19 +108,19 @@ describe("QFI", () => {
     fundingSourceAddress = await fundingSource.getAddress();
 
     // Mocked contracts.
-    mockBaseERC20Token = await deployMockContract(deployer, BaseERC20TokenAbi);
+    mockBaseERC20Token = await deployMockContract(deployer, BaseERC20Token__factory.abi);
     mockGrantRoundFactory = await deployMockContract(
       deployer,
-      GrantRoundFactoryAbi
+      GrantRoundFactory__factory.abi
     );
-    mockPollFactory = await deployMockContract(deployer, PollFactoryAbi);
+    mockPollFactory = await deployMockContract(deployer, PollFactory__factory.abi);
     mockFreeForAllGateKeeper = await deployMockContract(
       deployer,
-      SignUpGateKeeperAbi
+      SignUpGatekeeper__factory.abi
     );
     mockConstantInitialVoiceCreditProxy = await deployMockContract(
       deployer,
-      ConstantInitialVoiceCreditProxyAbi
+      ConstantInitialVoiceCreditProxy__factory.abi
     );
 
     // Poseidon libraries.
@@ -231,16 +231,16 @@ describe("QFI", () => {
   describe("initialize()", () => {
     before(async () => {
       // Mocked contracts.
-      mockVkRegistry = await deployMockContract(deployer, VkRegistryAbi);
+      mockVkRegistry = await deployMockContract(deployer, VkRegistry__factory.abi);
 
       mockMessageAqFactoryPolls = await deployMockContract(
         deployer,
-        MessageAqFactoryAbi
+        MessageAqFactory__factory.abi
       );
 
       mockMessageAqFactoryGrantRounds = await deployMockContract(
         deployer,
-        MessageAqFactoryAbi
+        MessageAqFactory__factory.abi
       );
     });
 
@@ -445,7 +445,7 @@ describe("QFI", () => {
   describe("setPollProcessorAndTallyer()", () => {
     before(async () => {
       // Mocked contracts.
-      mockPPT = await deployMockContract(deployer, PollProcessorAndTallyerAbi);
+      mockPPT = await deployMockContract(deployer, PollProcessorAndTallyer__factory.abi);
     });
 
     it("allows owner to set the PollProcessorAndTallyer", async () => {
@@ -468,7 +468,7 @@ describe("QFI", () => {
         .withArgs(mockPPT.address);
 
       // New PPT mock.
-      mockPPT = await deployMockContract(deployer, PollProcessorAndTallyerAbi);
+      mockPPT = await deployMockContract(deployer, PollProcessorAndTallyer__factory.abi);
       expect(firstMockedPPT).to.be.not.equal(mockPPT.address);
 
       // Should change the PPT correctly.
@@ -933,7 +933,7 @@ describe("QFI", () => {
   describe("deployGrantRound()", async () => {
     beforeEach(async () => {
       // Mocked contracts.
-      mockGrantRound = await deployMockContract(deployer, GrantRoundAbi);
+      mockGrantRound = await deployMockContract(deployer, GrantRound__factory.abi);
     });
 
     it("allow owner to deploy a grant round", async () => {

--- a/packages/contracts/tests/Unit/SimpleRecipientRegistry.ts
+++ b/packages/contracts/tests/Unit/SimpleRecipientRegistry.ts
@@ -1,7 +1,7 @@
 import { ethers } from "hardhat";
-import { ContractTransaction, ContractReceipt, Signer, constants } from "ethers";
+import { ContractTransaction, ContractReceipt, Signer } from "ethers";
 import chai from "chai";
-import { deployContract, deployMockContract, MockContract, solidity, } from "ethereum-waffle";
+import { solidity, } from "ethereum-waffle";
 import { SimpleRecipientRegistry } from "../../typechain";
 
 chai.use(solidity);


### PR DESCRIPTION
This PR will address the following issues:

- [x] #92 
- [x] Clean unused imports
- [x] Getting rid of `generate:abi` script (upload build script from @gurrpi, +1)

As explained in #92, this will flatten the imports methods for tests by looking into `typechain/` folder only. Also, this will allow avoiding the `generate:abi` script to be executed after building or before tests.