### PR TITLE
Feat/devops: Lighthouse report for desktop and subgraph build

### DIFF
--- a/.github/.lighthouserc.json
+++ b/.github/.lighthouserc.json
@@ -1,0 +1,9 @@
+{
+    "ci": {
+      "collect": {
+        "settings": {
+          "preset": "desktop"
+        }
+      }
+    }
+}

--- a/.github/workflows/frontend-lighthouse.yml
+++ b/.github/workflows/frontend-lighthouse.yml
@@ -4,6 +4,7 @@ on:
   issue_comment:
     types: [ edited ]
 
+
 jobs:
   capture_vercel_preview_url:
     name: Capture Vercel preview URL
@@ -15,13 +16,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
-      - name: Audit preview URL with Lighthouse
-        id: lighthouse_audit
+      - name: '[Mobile] Audit preview URL with Lighthouse'
+        id: lighthouse_audit_mobile
         uses: treosh/lighthouse-ci-action@v9
         with:
           urls: ${{ steps.vercel_preview_url.outputs.vercel_preview_url }}
-          uploadArtifacts: true
           temporaryPublicStorage: true
+          
+      - name: '[Desktop] Audit preview URL with Lighthouse'
+        id: lighthouse_audit_desktop
+        uses: treosh/lighthouse-ci-action@v9
+        with:
+          urls: ${{ steps.vercel_preview_url.outputs.vercel_preview_url }}
+          temporaryPublicStorage: true
+          configPath: './.github/.lighthouserc.json'
 
       - name: Format lighthouse score
         id: format_lighthouse_score
@@ -29,22 +37,37 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const result = ${{ steps.lighthouse_audit.outputs.manifest }}[0].summary
-            const links = ${{ steps.lighthouse_audit.outputs.links }}
+            const score = res => res >= 90 ? '🟢' : res >= 50 ? '🟠' : '🔴'          
             const formatResult = (res) => Math.round((res * 100))
-            Object.keys(result).forEach(key => result[key] = formatResult(result[key]))
-            const score = res => res >= 90 ? '🟢' : res >= 50 ? '🟠' : '🔴'
+
+            const desktop_result = ${{ steps.lighthouse_audit_desktop.outputs.manifest }}[0].summary
+            const desktop_links = ${{ steps.lighthouse_audit_desktop.outputs.links }}
+            Object.keys(desktop_result).forEach(key => desktop_result[key] = formatResult(desktop_result[key]))
+
+            const mobile_result = ${{ steps.lighthouse_audit_mobile.outputs.manifest }}[0].summary
+            const mobile_links = ${{ steps.lighthouse_audit_mobile.outputs.links }}
+            Object.keys(mobile_result).forEach(key => mobile_result[key] = formatResult(mobile_result[key]))
+            
             const comment = [
-                `⚡️ [Lighthouse report](${Object.values(links)[0]}) for the changes in this PR:`,
+                `⚡️ [(Desktop) Lighthouse report](${Object.values(desktop_links)[0]}) for the changes in this PR:`,
                 '| Category | Score |',
                 '| --- | --- |',
-                `| ${score(result.performance)} Performance | ${result.performance} |`,
-                `| ${score(result.accessibility)} Accessibility | ${result.accessibility} |`,
-                `| ${score(result['best-practices'])} Best practices | ${result['best-practices']} |`,
-                `| ${score(result.seo)} SEO | ${result.seo} |`,
-                `| ${score(result.pwa)} PWA | ${result.pwa} |`,
+                `| ${score(desktop_result.performance)} Performance | ${desktop_result.performance} |`,
+                `| ${score(desktop_result.accessibility)} Accessibility | ${desktop_result.accessibility} |`,
+                `| ${score(desktop_result['best-practices'])} Best practices | ${desktop_result['best-practices']} |`,
+                `| ${score(desktop_result.seo)} SEO | ${desktop_result.seo} |`,
+                `| ${score(desktop_result.pwa)} PWA | ${desktop_result.pwa} |`,
                 ' ',
-                `*Lighthouse ran on [${Object.keys(links)[0]}](${Object.keys(links)[0]})*`
+                `⚡️ [(Mobile) Lighthouse report](${Object.values(mobile_links)[0]}) for the changes in this PR:`,
+                '| Category | Score |',
+                '| --- | --- |',
+                `| ${score(mobile_result.performance)} Performance | ${mobile_result.performance} |`,
+                `| ${score(mobile_result.accessibility)} Accessibility | ${mobile_result.accessibility} |`,
+                `| ${score(mobile_result['best-practices'])} Best practices | ${mobile_result['best-practices']} |`,
+                `| ${score(mobile_result.seo)} SEO | ${mobile_result.seo} |`,
+                `| ${score(mobile_result.pwa)} PWA | ${mobile_result.pwa} |`,
+                ' ',
+                `*Lighthouse ran on [${Object.keys(mobile_links)[0]}](${Object.keys(mobile_links)[0]})*`
             ].join('\n')
             core.setOutput("comment", comment); 
 

--- a/.github/workflows/subgraph-build.yml
+++ b/.github/workflows/subgraph-build.yml
@@ -1,0 +1,33 @@
+name: Subgraph-Build
+
+on:
+  push: 
+    branches: [ main, dev ]
+    tags: ['*']
+  pull_request:
+
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+          
+      - name: Build
+        run: |
+          CI=false yarn workspace @quadratic-funding/subgraph codegen
+          CI=false yarn workspace @quadratic-funding/subgraph build


### PR DESCRIPTION
This PR add following feature to the CI:
* the workflow builds the `subgraph` sub-package
* Comments Lighthouse report for desktop along with mobile

Comments will looks like following screenshot:
<img width="931" alt="Screen Shot 2022-04-17 at 23 57 50" src="https://user-images.githubusercontent.com/1610146/163720121-35102162-93b2-4b7d-a355-f2d9e556cf03.png">

fixes: https://github.com/quadratic-funding/qfi/issues/101