### PR TITLE
Fix a broken URL detection of Vercel Preview

### DIFF
--- a/.github/workflows/frontend-lighthouse.yml
+++ b/.github/workflows/frontend-lighthouse.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: aaimio/vercel-preview-url-action@v1
         id: vercel_preview_url
         with:
+          preview_url_regexp: \[Visit Preview\]\((.*.app)\)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR updates regex to capture preview URL to supply it to Lighthouse CI action. Currently, [Lighthouse CI](https://github.com/quadratic-funding/qfi/actions/workflows/frontend-lighthouse.yml) has been broken due to the format of automated comment made by Vercel has been changed. 

Note that this change will be only enabled when it is on the default branch; `main` (see [this](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment)).