### PR TITLE
Fix unable to run pre-commit hook in Ubuntu

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,37 +1,6 @@
 #!/bin/sh
 
+BASE_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
-# Return `true` if files under `packages/contracts/contracts/` directory has been changed or added. Otherwise, return `false`
-is_contracts_changed()
-{
-    result="false"
-    git_changes=$(git diff --cached --name-status)
-
-    while read -r line; do
-        changed_file_path=$(echo "$line" | awk '/packages/ {print $2}')
-        file_status=$(echo "$line" | cut -c 1)
-
-        if [ "$file_status" = 'A' ] || [ "$file_status" = 'M' ]
-        then
-            case $changed_file_path in packages/contracts/contracts/*)
-                result="true"
-            esac
-        fi
-    done <<< "$git_changes"
-    
-    echo "$result"
-}
-
-
-. "$(dirname "$0")/_/husky.sh"
-
-
-# Check lint for all subpackage
-npx lint-staged
-
-RETURN_CODE=$(is_contracts_changed)
-if [ $RETURN_CODE = "true" ]; then
-    # Run contract tests
-    npx yarn workspace @quadratic-funding/contracts typechain
-    npx yarn workspace @quadratic-funding/contracts test:unit
-fi
+bash "$BASE_DIR"/scripts/_pre-commit
+exit "$?"

--- a/.husky/scripts/_pre-commit
+++ b/.husky/scripts/_pre-commit
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Return `true` if files under `packages/contracts/contracts/` directory has been changed or added. Otherwise, return `false`
+is_contracts_changed()
+{
+    result="false"
+    git_changes=$(git diff --cached --name-status)
+
+    while read -r line; do
+        changed_file_path=$(echo "$line" | awk '/packages/ {print $2}')
+        file_status=$(echo "$line" | cut -c 1)
+
+        if [ "$file_status" = 'A' ] || [ "$file_status" = 'M' ]
+        then
+            case $changed_file_path in packages/contracts/contracts/*)
+                result="true"
+            esac
+        fi
+    done <<< "$git_changes"
+    
+    echo "$result"
+}
+
+# Check lint for all subpackage
+npx lint-staged
+
+RETURN_CODE=$(is_contracts_changed)
+if [ $RETURN_CODE = "true" ]; then
+    # Run contract tests
+    npx yarn workspace @quadratic-funding/contracts typechain
+    npx yarn workspace @quadratic-funding/contracts test:unit
+fi


### PR DESCRIPTION
Fixes pre-commit hooks to executed by bash rather than other default shell set by OS; e.g. default shell of Ubuntu([dash](https://linux.die.net/man/1/dash)) didn't support 'here-string'(`<<<`) so it fails when running hook in Ubuntu.

Fixes: https://github.com/quadratic-funding/qfi/issues/109