### PR TITLE
Fix/mismatched arrays length

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,37 +1,6 @@
 #!/bin/sh
 
+BASE_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
-# Return `true` if files under `packages/contracts/contracts/` directory has been changed or added. Otherwise, return `false`
-is_contracts_changed()
-{
-    result="false"
-    git_changes=$(git diff --cached --name-status)
-
-    while read -r line; do
-        changed_file_path=$(echo "$line" | awk '/packages/ {print $2}')
-        file_status=$(echo "$line" | cut -c 1)
-
-        if [ "$file_status" = 'A' ] || [ "$file_status" = 'M' ]
-        then
-            case $changed_file_path in packages/contracts/contracts/*)
-                result="true"
-            esac
-        fi
-    done <<< "$git_changes"
-    
-    echo "$result"
-}
-
-
-. "$(dirname "$0")/_/husky.sh"
-
-
-# Check lint for all subpackage
-npx lint-staged
-
-RETURN_CODE=$(is_contracts_changed)
-if [ $RETURN_CODE = "true" ]; then
-    # Run contract tests
-    npx yarn workspace @qfi/contracts typechain
-    npx yarn workspace @qfi/contracts test:unit
-fi
+bash "$BASE_DIR"/scripts/_pre-commit
+exit "$?"

--- a/.husky/scripts/_pre-commit
+++ b/.husky/scripts/_pre-commit
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Return `true` if files under `packages/contracts/contracts/` directory has been changed or added. Otherwise, return `false`
+is_contracts_changed()
+{
+    result="false"
+    git_changes=$(git diff --cached --name-status)
+
+    while read -r line; do
+        changed_file_path=$(echo "$line" | awk '/packages/ {print $2}')
+        file_status=$(echo "$line" | cut -c 1)
+
+        if [ "$file_status" = 'A' ] || [ "$file_status" = 'M' ]
+        then
+            case $changed_file_path in packages/contracts/contracts/*)
+                result="true"
+            esac
+        fi
+    done <<< "$git_changes"
+    
+    echo "$result"
+}
+
+# Check lint for all subpackage
+npx lint-staged
+
+RETURN_CODE=$(is_contracts_changed)
+if [ $RETURN_CODE = "true" ]; then
+    # Run contract tests
+    npx yarn workspace @qfi/contracts typechain
+    npx yarn workspace @qfi/contracts test:unit
+fi

--- a/packages/contracts/contracts/GrantRound.sol
+++ b/packages/contracts/contracts/GrantRound.sol
@@ -127,6 +127,12 @@ contract GrantRound is Poll {
         Message[] calldata _messages,
         PubKey[] calldata _encPubKeys
     ) external {
+        // Check that the two arrays have the same length
+        require(
+            _messages.length == _encPubKeys.length, 
+            "GrantRound: _messages and _encPubKeys should be the same length"
+        );
+
         uint256 batchSize = _messages.length;
         for (uint8 i = 0; i < batchSize; i++) {
             publishMessage(_messages[i], _encPubKeys[i]);

--- a/packages/contracts/contracts/QFI.sol
+++ b/packages/contracts/contracts/QFI.sol
@@ -413,7 +413,7 @@ contract QFI is MACI, FundsManager {
     function closeVotingAndWaitForDeadline() public onlyOwner {
         require(
             currentStage == Stage.VOTING_PERIOD_OPEN,
-            "MACI: WAITING_FOR_SIGNUPS_AND_TOPUPS Cannot deploy a new grant round"
+            "QFI: Cannot finalize a grant round while not in the VOTING_PERIOD_OPEN stage"
         );
         //TODO: ACTUALLY CLOSE THE VOTING PERIOD on the grant round contract
         currentStage = Stage.WAITING_FOR_FINALIZATION;
@@ -458,7 +458,7 @@ contract QFI is MACI, FundsManager {
     function acceptContributionsAndTopUpsBeforeNewRound() public onlyOwner {
         require(
             currentStage == Stage.FINALIZED,
-            "QFI: Cannot deploy a new grant round while not in the WAITING_FOR_SIGNUPS_AND_TOPUPS stage"
+            "QFI: Cannot deploy a new grant round while not in the FINALIZED stage"
         );
         currentStage = Stage.WAITING_FOR_SIGNUPS_AND_TOPUPS;
 

--- a/packages/contracts/tests/Unit/GrantRound.ts
+++ b/packages/contracts/tests/Unit/GrantRound.ts
@@ -329,6 +329,28 @@ describe("Grant Round", () => {
       ).to.be.revertedWith("PollE03");
     });
 
+    it("revert - array length mismatch", async () => {
+      // Mocks.
+      // nb. in this case the return from enqueue() it is not useful.
+      await mockMessageAq.mock.enqueue
+        .withArgs(hashMessangeAndEncPubKey)
+        .returns(0);
+
+      // Sending batchMessage with mismatched arrays
+      await expect(
+        grantRound
+          .connect(voter)
+          .publishMessageBatch(
+            [message, message, message, message], // Extra message (4 messages and 3 public keys)
+            [
+              coordinatorMaciPublicKey.asContractParam(),
+              coordinatorMaciPublicKey.asContractParam(),
+              coordinatorMaciPublicKey.asContractParam(),
+            ]
+          )
+      ).to.be.revertedWith("GrantRound: _messages and _encPubKeys should be the same length"); 
+    });
+
     it("revert - max number of messages reached", async () => {
       // Mocks.
       await mockMessageAq.mock.enqueue

--- a/packages/contracts/tests/Unit/QFI.ts
+++ b/packages/contracts/tests/Unit/QFI.ts
@@ -1188,7 +1188,7 @@ describe("QFI", () => {
 
     it("revert - cannot close the voting period while not on voting period open", async () => {
       await expect(qfi.connect(deployer).closeVotingAndWaitForDeadline()).to.revertedWith(
-        "MACI: WAITING_FOR_SIGNUPS_AND_TOPUPS Cannot deploy a new grant round"
+        "QFI: Cannot finalize a grant round while not in the VOTING_PERIOD_OPEN stage"
       );
     });
   });
@@ -1609,7 +1609,7 @@ describe("QFI", () => {
 
     it("revert - cannot start accepting new contributions/signups while the current grant round is not finalized yet", async () => {
       await expect(qfi.connect(deployer).acceptContributionsAndTopUpsBeforeNewRound()).to.revertedWith(
-        "QFI: Cannot deploy a new grant round while not in the WAITING_FOR_SIGNUPS_AND_TOPUPS stage"
+        "QFI: Cannot deploy a new grant round while not in the FINALIZED stage"
       );
     });
   });


### PR DESCRIPTION
Fix(grantround.sol): 

check to prevent mismatched array arguments in `publishMessageBatch`

Added a `require` statement that checks that the length of the two array parameters (_messages and
_encPubKeys) are the same. Also implemented a test case to verify this works as expected.

fix https://github.com/quadratic-funding/qfi/issues/158